### PR TITLE
Filter out jobs without CI_IMAGE_TAG defined

### DIFF
--- a/templates/v2/common.yml
+++ b/templates/v2/common.yml
@@ -6,3 +6,9 @@ stages:
 
 variables:
   JULIA_DEPOT_PATH: "$CI_PROJECT_DIR/.julia/"
+
+# Root job that other jobs extend
+.root:
+  only:
+    variables:
+      - $CI_IMAGE_TAG

--- a/templates/v2/coverage_dev.yml
+++ b/templates/v2/coverage_dev.yml
@@ -1,5 +1,6 @@
 coverage:
   stage: post
+  extends: .root
   image: "juliagpu/julia:dev-${CI_IMAGE_TAG}"
   dependencies:
     - test:dev

--- a/templates/v2/coverage_v1.0.yml
+++ b/templates/v2/coverage_v1.0.yml
@@ -1,5 +1,6 @@
 coverage:
   stage: post
+  extends: .root
   image: "juliagpu/julia:v1.0-${CI_IMAGE_TAG}"
   dependencies:
     - test:v1.0

--- a/templates/v2/coverage_v1.1.yml
+++ b/templates/v2/coverage_v1.1.yml
@@ -1,5 +1,6 @@
 coverage:
   stage: post
+  extends: .root
   image: "juliagpu/julia:v1.1-${CI_IMAGE_TAG}"
   dependencies:
     - test:v1.1

--- a/templates/v2/documentation_dev.yml
+++ b/templates/v2/documentation_dev.yml
@@ -1,5 +1,6 @@
 documentation:
   stage: post
+  extends: .root
   image: "juliagpu/julia:dev-${CI_IMAGE_TAG}"
   variables:
     DOCUMENTER_DEBUG: "true"

--- a/templates/v2/documentation_v1.0.yml
+++ b/templates/v2/documentation_v1.0.yml
@@ -1,5 +1,6 @@
 documentation:
   stage: post
+  extends: .root
   image: "juliagpu/julia:v1.0-${CI_IMAGE_TAG}"
   variables:
     DOCUMENTER_DEBUG: "true"

--- a/templates/v2/documentation_v1.1.yml
+++ b/templates/v2/documentation_v1.1.yml
@@ -1,5 +1,6 @@
 documentation:
   stage: post
+  extends: .root
   image: "juliagpu/julia:v1.1-${CI_IMAGE_TAG}"
   variables:
     DOCUMENTER_DEBUG: "true"

--- a/templates/v2/test_dev.yml
+++ b/templates/v2/test_dev.yml
@@ -1,5 +1,6 @@
 test:dev:
   stage: test
+  extends: .root
   image: "juliagpu/julia:dev-${CI_IMAGE_TAG}"
   script:
     - julia -e 'using InteractiveUtils;

--- a/templates/v2/test_v0.7.yml
+++ b/templates/v2/test_v0.7.yml
@@ -1,5 +1,6 @@
 test:v0.7:
   stage: test
+  extends: .root
   image: "juliagpu/julia:v0.7-${CI_IMAGE_TAG}"
   script:
     - julia -e 'using InteractiveUtils;

--- a/templates/v2/test_v1.0.yml
+++ b/templates/v2/test_v1.0.yml
@@ -1,5 +1,6 @@
 test:v1.0:
   stage: test
+  extends: .root
   image: "juliagpu/julia:v1.0-${CI_IMAGE_TAG}"
   script:
     - julia -e 'using InteractiveUtils;

--- a/templates/v2/test_v1.1.yml
+++ b/templates/v2/test_v1.1.yml
@@ -1,5 +1,6 @@
 test:v1.1:
   stage: test
+  extends: .root
   image: "juliagpu/julia:v1.1-${CI_IMAGE_TAG}"
   script:
     - julia -e 'using InteractiveUtils;


### PR DESCRIPTION
1. Define a root job with a variables filter
2. Let all other jobs inherit from `.root`

https://docs.gitlab.com/ee/ci/yaml/#extends