### PR TITLE
Temporarily disable MIOpen in rocm

### DIFF
--- a/images/derived/rocm/Dockerfile
+++ b/images/derived/rocm/Dockerfile
@@ -15,8 +15,8 @@ RUN apt-get update && \
                     # common package dependencies
                     build-essential gfortran \
                     # ROCm external libraries
-                    rocblas rocsparse rocfft rocrand rocalution \
-                    miopen-hip miopen-opencl && \
+                    rocblas rocsparse rocfft rocrand rocalution && \
+                    #miopen-hip miopen-opencl && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I stupidly didn't test the last PR, and found out that the two MIOpen packages can't be installed at the same time. Since I don't know which I'll need, I'm disabling both of them for now.

I made sure to test this PR locally, and it works as I expect :smile: