### PR TITLE
Add pipelines for rebuilding content

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,3 +139,36 @@ When doing development to the templates in this repository, do know that the
 template files as included by GitLab CI/CD configurations are cached. To
 effectively iterate on the template files, be sure to include the commit hash in
 the path to the template files.
+
+
+## Content Rebuilding Pipelines
+
+[SciML/DiffEqTutorials.jl](https://github.com/SciML/DiffEqTutorials.jl) and
+[SciML/DiffEqBenchmarks.jl](https://github.com/SciML/DiffEqBenchmarks.jl)
+both use the same process for keeping their content up to date, which is defined here.
+If you want to apply the same workflow to another repository, here's what you need to do:
+
+* Import your project into JuliaGPU on GitLab as described above
+
+* Add a `.gitlab-ci.yml` file to your repository with the following contents:
+
+```yml
+include: https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/templates/rebuild/v1.yml
+variables:
+  CONTENT_DIR: mycontent  # Required, directory holding your source content
+  GITHUB_REPOSITORY: Owner/Repo  # Required, GitHub user/repository name (no .git)
+  EXCLUDE: folder/file1, folder/file2  # Optional, content to not rebuild automatically
+  NEEDS_GPU: folder/file1, folder/file2  # Optional, content that needs a GPU to build
+  TAGS: tag1, tag2  # Optional, tags to add to GitLab rebuild jobs
+```
+
+* Copy [`templates/rebuild/actions.yml`](templates/rebuild/actions.yml) to `.github/workflows/rebuild.yml` in your repository
+
+* Generate an SSH key pair, and add the public key as a deploy key with write permissions
+  to your GitHub repo. Then, add the private key as a
+  [File environment variable](https://docs.gitlab.com/ee/ci/variables/README.html#custom-environment-variables-of-type-file)
+  with the name `SSH_KEY` in GitLab.
+
+* Find your GitLab project ID and add it as a GitHub secret called `GITLAB_PROJECT`
+
+* Create a Gitlab [pipeline trigger](https://docs.gitlab.com/ee/ci/triggers/#adding-a-new-trigger) and add the token as a GitHub secret called `GITLAB_TOKEN`

--- a/README.md
+++ b/README.md
@@ -172,3 +172,10 @@ variables:
 * Find your GitLab project ID and add it as a GitHub secret called `GITLAB_PROJECT`
 
 * Create a Gitlab [pipeline trigger](https://docs.gitlab.com/ee/ci/triggers/#adding-a-new-trigger) and add the token as a GitHub secret called `GITLAB_TOKEN`
+
+Once all that is done, a random piece of content will be rebuilt and a PR will be opened
+every 3 days. You can also manually rebuild by creating an issue comment with the contents:
+
+```
+!rebuild folder/file
+```

--- a/README.md
+++ b/README.md
@@ -177,5 +177,18 @@ Once all that is done, a random piece of content will be rebuilt and a PR will b
 every 3 days. You can also manually rebuild by creating an issue comment with the contents:
 
 ```
-!rebuild folder/file
+!rebuild file=folder/file
+```
+
+If you want to specify the branch name, for example if you want a PR to be updated,
+you can add the `branch` input:
+
+```
+!rebuild file=folder/file branch=name
+```
+
+You can also manually trigger a random rebuild by simply commenting:
+
+```
+!rebuild
 ```

--- a/make_rebuild_pipeline.py
+++ b/make_rebuild_pipeline.py
@@ -1,0 +1,74 @@
+import os
+
+from random import choice
+from sys import stdout
+from uuid import uuid4
+
+import yaml
+
+
+def env_list(k):
+    return [s.strip() for s in os.getenv(k, "").split(",") if s]
+
+
+folder = os.getenv("FOLDER")
+file = os.getenv("FILE")
+if not folder or not file:
+    cwd = os.getcwd()
+    os.chdir(os.environ["CONTENT_DIR"])
+    exclude = env_list("EXCLUDE")
+    dirs = [d for d in os.listdir() if os.path.isdir(d)]
+    choices = [
+        (d, f) for d in dirs for f in os.listdir(d)
+        if f.endswith(".jmd") and f"{d}/{f}" not in exclude
+    ]
+    folder, file = choice(choices)
+    os.chdir(cwd)
+
+tags = env_list("TAGS")
+if f"{folder}/{file}" in env_list("NEEDS_GPU"):
+    tags.append("nvidia")
+
+package = os.environ["GITHUB_REPOSITORY"].split("/")[1]
+if package.endswith(".jl"):
+    package = package[:-3]
+
+script = f"""
+julia -e '
+  using Pkg
+  Pkg.instantiate()
+  using {package}: weave_file
+  weave_file("{folder}", "{file}")'
+
+if [[ -z "$(git status -suno)" ]]; then
+  echo "No changes"
+  exit 0
+fi
+
+k="$(cat $SSH_KEY)"
+echo "$k" > "$SSH_KEY"
+chmod 400 "$SSH_KEY"
+git config core.sshCommand "ssh -o StrictHostKeyChecking=no -i $SSH_KEY"
+git config user.name "github-actions[bot]"
+git config user.email "actions@github.com"
+branch="rebuild/{str(uuid4())[:8]}"
+git checkout -b "$branch"
+git commit -am "Rebuild content"
+git remote add github "git@github.com:$GITHUB_REPOSITORY.git"
+git push github "$branch"
+"""
+
+pipeline = {
+    "include": "https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/templates/v6.yml",
+    "rebuild": {
+        "extends": ".julia:1.4",
+        "variables": {
+            "CI_APT_INSTALL": "git python3-dev texlive-science texlive-xetex",
+            "JULIA_NUM_THREADS": 4,
+        },
+        "tags": tags,
+        "script": script,
+    },
+}
+
+yaml.dump(pipeline, stdout)

--- a/make_rebuild_pipeline.py
+++ b/make_rebuild_pipeline.py
@@ -63,7 +63,7 @@ pipeline = {
     "rebuild": {
         "extends": ".julia:1.4",
         "variables": {
-            "CI_APT_INSTALL": "git python3-dev texlive-science texlive-xetex",
+            "CI_APT_INSTALL": "gfortran git python3-dev texlive-science texlive-xetex",
             "JULIA_NUM_THREADS": 4,
         },
         "tags": tags,

--- a/templates/rebuild/actions.yml
+++ b/templates/rebuild/actions.yml
@@ -1,0 +1,76 @@
+name: Rebuild Content
+on:
+  schedule:
+    - cron: 0 0 */3 * *
+  issue_comment:
+    types:
+      - created
+  push:
+  status:
+env:
+  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
+  GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/${{ secrets.GITLAB_PROJECT }}/trigger/pipeline
+jobs:
+  RandomRebuild:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl --fail \
+            -F "token=$GITLAB_TOKEN" \
+            -F "ref=master" \
+            "$GITLAB_TRIGGER"
+  ManualRebuild:
+    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          arg="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2)"
+          folder="$(echo $arg | cut -d/ -f1)"
+          file="$(echo $arg | cut -d/ -f2)"
+          curl --fail \
+            -F "token=$GITLAB_TOKEN" \
+            -F "ref=master" \
+            -F "variables[FOLDER]=$folder" \
+            -F "variables[FILE]=$file" \
+            "$GITLAB_TRIGGER"
+      - uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.reactions.createForIssueComment({
+              ...context.repo,
+              comment_id: context.payload.comment.id,
+              content: "+1",
+            })
+  OpenPR:
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/heads/rebuild/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.pulls.create({
+              ...context.repo,
+              title: "Rebuild content,
+              head: "${{ github.ref }}".slice(11),
+              base: "master",
+            })
+  FixStatus:
+    if: github.event_name == 'status' && github.event.context == 'ci/gitlab/gitlab.com' && github.event.state == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      # TODO: Replace this SHA with a tag when the next version is released.
+      - uses: actions/github-script@82b33c82ef5e155cb8e0de0862e5dbde0cd451eb
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitStatus({
+              ...context.repo,
+              sha: context.payload.sha,
+              state: "success",
+              context: context.payload.context,
+              description: "This status can be ignored",
+              target_url: context.payload.target_url,
+            })

--- a/templates/rebuild/actions.yml
+++ b/templates/rebuild/actions.yml
@@ -7,34 +7,45 @@ on:
       - created
   push:
   status:
-env:
-  GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
-  GITLAB_TRIGGER: https://gitlab.com/api/v4/projects/${{ secrets.GITLAB_PROJECT }}/trigger/pipeline
 jobs:
-  RandomRebuild:
-    if: github.event_name == 'schedule'
+  TriggerRebuild:
+    if: github.event_name == 'schedule' || github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
     runs-on: ubuntu-latest
     steps:
       - run: |
+          cmd="$(jq -r .comment.body < "$GITHUB_EVENT_PATH" | head -n1 | cut -d' ' -f2-)"
+          while [[ "$cmd" != '' && "$cmd" != '!rebuild' ]]; do
+            arg="$(echo $cmd | cut -d' ' -f1)"
+            key="$(echo $arg | cut -d= -f1)"
+            val="$(echo $arg | cut -d= -f2)"
+            case "$key" in
+              branch)
+                branch="$val"
+                ;;
+              file)
+                folder="$(echo $val | cut -d/ -f1)"
+                file="$(echo $val | cut -d/ -f2)"
+                ;;
+              *)
+                echo "Unknown command $key"
+                exit 1
+                ;;
+            esac
+            if echo "$cmd" | grep -q ' '; then
+              cmd="$(echo $cmd | cut -d' ' -f2)"
+            else
+              cmd=""
+            fi
+          done
           curl --fail \
-            -F "token=$GITLAB_TOKEN" \
+            -F "token=${{ secrets.GITLAB_TOKEN }}" \
             -F "ref=master" \
-            "$GITLAB_TRIGGER"
-  ManualRebuild:
-    if: github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!rebuild')
-    runs-on: ubuntu-latest
-    steps:
-      - run: |
-          arg="$(echo '${{ github.event.comment.body }}' | head -n1 | cut -d' ' -f2)"
-          folder="$(echo $arg | cut -d/ -f1)"
-          file="$(echo $arg | cut -d/ -f2)"
-          curl --fail \
-            -F "token=$GITLAB_TOKEN" \
-            -F "ref=master" \
+            -F "variables[BRANCH]=$branch" \
             -F "variables[FOLDER]=$folder" \
             -F "variables[FILE]=$file" \
-            "$GITLAB_TRIGGER"
-      - uses: actions/github-script@v2
+            "https://gitlab.com/api/v4/projects/${{ secrets.GITLAB_PROJECT }}/trigger/pipeline"
+      - if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/templates/rebuild/v1.yml
+++ b/templates/rebuild/v1.yml
@@ -1,0 +1,30 @@
+stages:
+  - setup
+  - rebuild
+
+setup:
+  stage: setup
+  only:
+    - triggers
+  image: python
+  script: |
+    for var in CONTENT_DIR GITHUB_REPOSITORY SSH_KEY; do
+      if [[ ! -v "$var" ]]; then
+        echo "Missing environment variable '$var'"
+      fi
+    done
+    curl -LO https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/make_rebuild_pipeline.py
+    pip install pyyaml
+    python make_rebuild_pipeline.py > rebuild.yml
+  artifacts:
+    paths:
+      - rebuild.yml
+
+rebuild:
+  stage: rebuild
+  trigger:
+    include:
+      - artifact: rebuild.yml
+        job: setup
+  variables:  # TODO: Delete after JuliaGPU/gitlab-ci#20
+    JULIA_PROJECT: "@."

--- a/templates/rebuild/v1.yml
+++ b/templates/rebuild/v1.yml
@@ -26,5 +26,6 @@ rebuild:
     include:
       - artifact: rebuild.yml
         job: setup
+    strategy: depend
   variables:  # TODO: Delete after JuliaGPU/gitlab-ci#20
     JULIA_PROJECT: "@."

--- a/templates/rebuild/v1.yml
+++ b/templates/rebuild/v1.yml
@@ -13,7 +13,7 @@ setup:
         echo "Missing environment variable '$var'"
       fi
     done
-    curl -LO https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/make_rebuild_pipeline.py
+    curl -LO https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/cdg/rebuilds/make_rebuild_pipeline.py
     pip install pyyaml
     python make_rebuild_pipeline.py > rebuild.yml
   artifacts:


### PR DESCRIPTION
This is already used by DiffEqTutorials and I'm in the middle of replicating it for DiffEqBenchmarks, so I thought it would be good to centralize it here. Maybe it belongs in a different repo in SciML specifically, if so just let me know.
Because GitHub Actions are used and there's no `include` function like GitLab CI has, there's really not that much reduction in duplication... but at least here it can act as a reference file.