### PR TITLE
Add a .julia:1 target for 1.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ test:1.0:
     - .julia:1.0
     - .test
 
+test:1.x:
+  extends: 
+    - .julia:1
+    - .test
+
 test:nightly:
   extends:
     - .julia:nightly

--- a/templates/v6.yml
+++ b/templates/v6.yml
@@ -55,7 +55,7 @@ cache:
       wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh
       eval "$(bash install_julia.sh 1.3)"
 
-.julia:1.4:
+.julia:1.4: &1
   before_script:
     - |
       apt-get -qq update
@@ -70,6 +70,9 @@ cache:
       DEBIAN_FRONTEND=noninteractive apt-get -qqy -o=Dpkg::Use-Pty=0 install wget $CI_APT_INSTALL
       wget -nv https://raw.githubusercontent.com/JuliaGPU/gitlab-ci/master/install_julia.sh
       eval "$(bash install_julia.sh 1.5)"
+
+.julia:1:
+  <<: *1
 
 .julia:nightly:
   before_script:


### PR DESCRIPTION
Closes #23 

For maintenance, we just need to make sure to move the `&1` anchor for new Julia stable releases.